### PR TITLE
feat: replace lo.IsSortedByKey & lo.RuneLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,20 +126,6 @@ idx := lo.IndexOf(slice, target)
 idx := slices.Index(slice, target)
 ```
 
-#### `LastIndexOf`
-
-**Before:**
-
-```go
-idx := lo.LastIndexOf(slice, target)
-```
-
-**After:**
-
-```go
-idx := slices.LastIndex(slice, target)
-```
-
 #### `Min`
 
 **Before:**
@@ -222,6 +208,24 @@ if slices.IsSorted(slice) {
 }
 ```
 
+#### `IsSortedByKey`
+
+**Before:**
+
+```go
+sorted := lo.IsSortedByKey(slice, func(a string) string {
+	return a
+})
+```
+
+**After:**
+
+```go
+sorted := slices.IsSortedFunc(slice, func(a, next string) int {
+	return cmp.Compare(a, next)
+})
+```
+
 #### `Flatten`
 
 **Before:**
@@ -276,6 +280,20 @@ result := lo.CoalesceOrEmpty(s1, s2, s3)
 
 ```go
 result := cmp.Or(s1, s2, s3)
+```
+
+#### `RuneLength`
+
+**Before:**
+
+```go
+n := lo.RuneLength(s)
+```
+
+**After:**
+
+```go
+n := utf8.RuneCountInString(s)
 ```
 
 </details>

--- a/testdata/go1.23/lo.go
+++ b/testdata/go1.23/lo.go
@@ -31,14 +31,28 @@ func _(a []string, b string, c [][]string) {
 	lo.MaxBy(a, func(x, y string) bool { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return x > y
 	})
-	lo.IsSorted(a) // want `lo.IsSorted can be replaced with slices.IsSorted`
-	lo.Flatten(c)  // want `lo.Flatten can be replaced with slices.Concat`
+	lo.IsSorted(a)                              // want `lo.IsSorted can be replaced with slices.IsSorted`
+	lo.IsSortedByKey(a, func(x string) string { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return x
+	})
+	lo.IsSortedByKey(a, func(x string) int { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		if b == "" {
+			return len(x) % 2
+		}
+		return len(x)
+	})
+	lo.Flatten(c) // want `lo.Flatten can be replaced with slices.Concat`
 }
 
 // Maps.
 func _(a map[string]string, b string) {
 	lo.Keys(a)   // want `lo.Keys can be replaced with maps.Keys`
 	lo.Values(a) // want `lo.Values can be replaced with maps.Values`
+}
+
+// Strings.
+func _(a string) {
+	lo.RuneLength(a) // want `lo.RuneLength can be replaced with utf8.RuneCountInString`
 }
 
 // Helpers.

--- a/testdata/go1.23/lo.go.golden
+++ b/testdata/go1.23/lo.go.golden
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"maps"
 	"slices"
+	"utf8"
 )
 
 // Slices.
@@ -35,7 +36,16 @@ func _(a []string, b string, c [][]string) {
 	slices.MaxFunc(a, func(x, y string) int { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return cmp.Compare(x, y)
 	})
-	slices.IsSorted(a)  // want `lo.IsSorted can be replaced with slices.IsSorted`
+	slices.IsSorted(a)                                // want `lo.IsSorted can be replaced with slices.IsSorted`
+	slices.IsSortedFunc(a, func(x, next string) int { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return cmp.Compare(x, next)
+	})
+	slices.IsSortedFunc(a, func(x, next string) int { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		if b == "" {
+			return cmp.Compare(len(x)%2, len(next)%2)
+		}
+		return cmp.Compare(len(x), len(next))
+	})
 	slices.Concat(c...) // want `lo.Flatten can be replaced with slices.Concat`
 }
 
@@ -43,6 +53,11 @@ func _(a []string, b string, c [][]string) {
 func _(a map[string]string, b string) {
 	maps.Keys(a)   // want `lo.Keys can be replaced with maps.Keys`
 	maps.Values(a) // want `lo.Values can be replaced with maps.Values`
+}
+
+// Strings.
+func _(a string) {
+	utf8.RuneCountInString(a) // want `lo.RuneLength can be replaced with utf8.RuneCountInString`
 }
 
 // Helpers.

--- a/testdata/go1.23/lo_no_fix.go
+++ b/testdata/go1.23/lo_no_fix.go
@@ -8,14 +8,31 @@ func less(a, b string) bool {
 	return a < b
 }
 
+func key(a string) int {
+	return len(a)
+}
+
 // Slices.
 func _(a []string, b string, c [][]string) {
-	lo.MinBy(a, less)                    // want `lo.MinBy can be replaced with slices.MinFunc`
+	lo.MinBy(a, less)                         // want `lo.MinBy can be replaced with slices.MinFunc`
+	lo.MinBy(a, func(x, y string) (ok bool) { // want `lo.MinBy can be replaced with slices.MinFunc`
+		return
+	})
 	lo.MaxBy(a, less)                    // want `lo.MaxBy can be replaced with slices.MaxFunc`
 	lo.MaxBy(a, func(x, y string) bool { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return less(x, y)
 	})
 	lo.MaxBy(a, func(x, y string) bool { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return x == y
+	})
+	lo.IsSortedByKey(a, key)               // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+	lo.IsSortedByKey(a, func(string) int { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return 1
+	})
+	lo.IsSortedByKey(a, func(x string) (y int) { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return
+	})
+	lo.IsSortedByKey(a, func(x string) string { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return b
 	})
 }

--- a/testdata/go1.23/lo_no_fix.go.golden
+++ b/testdata/go1.23/lo_no_fix.go.golden
@@ -10,12 +10,25 @@ func less(a, b string) bool {
 
 // Slices.
 func _(a []string, b string, c [][]string) {
-	lo.MinBy(a, less) // want `lo.MinBy can be replaced with slices.MinFunc`
-	lo.MaxBy(a, less) // want `lo.MaxBy can be replaced with slices.MaxFunc`
+	lo.MinBy(a, less)                         // want `lo.MinBy can be replaced with slices.MinFunc`
+	lo.MinBy(a, func(x, y string) (ok bool) { // want `lo.MaxBy can be replaced with slices.MaxFunc`
+		return
+	})
+	lo.MaxBy(a, less)                    // want `lo.MaxBy can be replaced with slices.MaxFunc`
 	lo.MaxBy(a, func(x, y string) bool { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return less(x, y)
 	})
 	lo.MaxBy(a, func(x, y string) bool { // want `lo.MaxBy can be replaced with slices.MaxFunc`
 		return x == y
+	})
+	lo.IsSortedByKey(a, key)               // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+	lo.IsSortedByKey(a, func(string) int { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return 1
+	})
+	lo.IsSortedByKey(a, func(x string) (y int) { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return
+	})
+	lo.IsSortedByKey(a, func(x string) string { // want `lo.IsSortedByKey can be replaced with slices.IsSortedFunc`
+		return b
 	})
 }


### PR DESCRIPTION
- Add replacements for `lo.IsSortedByKey` & `lo.RuneLength`.
- Don't suggest edits for naked returns on `lo.MinBy` & `lo.MaxBy`
- Remove some needless checks & comments on rewrite funcs.